### PR TITLE
CDP-615: Update languages property to match schema for translated posts

### DIFF
--- a/includes/class-es-api-helpers.php
+++ b/includes/class-es-api-helpers.php
@@ -82,23 +82,8 @@ if ( !class_exists( 'ES_API_HELPER' ) ) {
     }
 
     public static function get_related_translated_posts( $id, $post_type ) {
-      global $sitepress;
-      if ( $sitepress ) {
-        // @todo Move all language related info to Language helper
-        $languages = array('en', 'es', 'fr', 'pt-br', 'ru', 'ar', 'zh-hans', 'fa', 'id', 'pt-pt');
-        $translations = array();
-
-        foreach ($languages as $language) {
-          $tmp = icl_object_id($id, $post_type, false, $language);
-          if ($tmp !== null) {
-            $translations[] = array(
-              'language' => $language,
-              'id' => icl_object_id($id, $post_type, false, $language)
-            );
-          }
-        }
-        return $translations;
-      }
+      global $cdp_language_helper;
+      return $cdp_language_helper->get_translations( $id );
     }
 
     public static function get_categories( $id ) {

--- a/includes/class-language-config.php
+++ b/includes/class-language-config.php
@@ -99,6 +99,10 @@ class Language_Helper {
     foreach ($results as $result) {
       $lang = $this->get_language_by_code($result->language_code);
       if (!$lang) continue;
+      $status = get_post_status($result->element_id);
+      if ($status !== 'publish') continue;
+      $sync = get_post_meta($result->element_id, '_iip_index_post_to_cdp_option', true);
+      if ($sync !== 'yes') continue;
       $translations[] = [
         'post_id' => $result->element_id,
         'language' => $lang

--- a/includes/class-language-config.php
+++ b/includes/class-language-config.php
@@ -102,7 +102,7 @@ class Language_Helper {
       $status = get_post_status($result->element_id);
       if ($status !== 'publish') continue;
       $sync = get_post_meta($result->element_id, '_iip_index_post_to_cdp_option', true);
-      if ($sync !== 'yes') continue;
+      if ($sync === 'no') continue;
       $translations[] = [
         'post_id' => $result->element_id,
         'language' => $lang


### PR DESCRIPTION
Added a function for grabbing all of the post translations from the WPML translation table.
The function then calls another added function that tries to match the language code to a CDP locale or code (if no locale match).
Translated posts will now match the current schema.