### PR TITLE
 CDP-757: Put all taxonomies into site_taxonomies property

### DIFF
--- a/includes/class-elasticsearch-wp-rest-api-controller.php
+++ b/includes/class-elasticsearch-wp-rest-api-controller.php
@@ -128,17 +128,8 @@ if ( !class_exists( 'WP_ES_FEEDER_REST_Controller' ) ) {
         $response = $this->prepare_item_for_response( $post, $request );
         $data = $response->get_data();
 
-        $categories = array_map( function ($cat) { return $cat['name']; }, ES_API_HELPER::get_categories( $post->ID ) );
-        $tags = array_map( function ($tag) { return $tag['name']; }, ES_API_HELPER::get_tags( $post->ID ) );
-        foreach ( $categories as $cat ) {
-          $cat = strtolower( $cat );
-          if ( !in_array( $cat, $tags ) ) $tags[] = $cat;
-        }
-        foreach ( $tags as $tag ) {
-          $tag = strtolower( $tag );
-          if ( !in_array( $tag, $tags ) ) $tags[] = $tag;
-        }
-        $data[ 'tags' ] = $tags;
+        $data[ 'site_taxonomies' ] = ES_API_HELPER::get_site_taxonomies( $post->ID );
+
         $categories = get_post_meta($id, '_iip_taxonomy_terms', true) ?: array();
         $cat_ids = array();
         foreach ($categories as $cat) {
@@ -241,10 +232,8 @@ if ( !class_exists( 'WP_ES_FEEDER_REST_Controller' ) ) {
       $post_data[ 'language' ] = ES_API_HELPER::get_language( $post->ID );
       $post_data[ 'languages' ] = ES_API_HELPER::get_related_translated_posts( $post->ID, $post->post_type ) ?: [];
 
-      $custom_taxonomies = ES_API_HELPER::get_custom_taxonomies( $post->ID );
-      if ( count( $custom_taxonomies ) ) {
-        $post_data['custom_taxonomies'] = $custom_taxonomies;
-      }
+      if ( array_key_exists( 'tags', $post_data ) ) $post_data[ 'tags' ] = [];
+      if ( array_key_exists( 'categories', $post_data ) ) $post_data[ 'categories' ] = [];
 
       $post_data[ 'thumbnail' ] = ES_API_HELPER::get_image_size_array( get_post_thumbnail_id( $post->ID ) );
 

--- a/includes/class-elasticsearch-wp-rest-api-controller.php
+++ b/includes/class-elasticsearch-wp-rest-api-controller.php
@@ -232,8 +232,8 @@ if ( !class_exists( 'WP_ES_FEEDER_REST_Controller' ) ) {
       $post_data[ 'language' ] = ES_API_HELPER::get_language( $post->ID );
       $post_data[ 'languages' ] = ES_API_HELPER::get_related_translated_posts( $post->ID, $post->post_type ) ?: [];
 
-      if ( array_key_exists( 'tags', $post_data ) ) $post_data[ 'tags' ] = [];
-      if ( array_key_exists( 'categories', $post_data ) ) $post_data[ 'categories' ] = [];
+      if ( !array_key_exists( 'tags', $post_data ) ) $post_data[ 'tags' ] = [];
+      if ( !array_key_exists( 'categories', $post_data ) ) $post_data[ 'categories' ] = [];
 
       $post_data[ 'thumbnail' ] = ES_API_HELPER::get_image_size_array( get_post_thumbnail_id( $post->ID ) );
 

--- a/includes/class-es-api-helpers.php
+++ b/includes/class-es-api-helpers.php
@@ -111,8 +111,8 @@ if ( !class_exists( 'ES_API_HELPER' ) ) {
     }
     
 
-    public static function get_custom_taxonomies( $id ) {
-      $custom_taxonomies = get_taxonomies( array( 'public' => true, '_builtin' => false) ); 
+    public static function get_site_taxonomies( $id ) {
+      $custom_taxonomies = get_taxonomies( array( 'public' => true) );
       $taxonomies = get_post_taxonomies( $id );   
 
       $output = array();
@@ -122,6 +122,9 @@ if ( !class_exists( 'ES_API_HELPER' ) ) {
           if( in_array($taxonomy, $custom_taxonomies ) ) {
             $terms = wp_get_post_terms( $id,  $taxonomy, array('fields' => 'all') );
             if( count($terms) ) {
+              // rename the key from WordPress defaults for categories and tags to align with what CDP expects
+              if ( $taxonomy === 'category' ) $taxonomy = 'categories';
+              else if ( $taxonomy === 'post_tag' ) $taxonomy = 'tags';
               $output[$taxonomy] = self::remap_terms( $terms );
             }
           }


### PR DESCRIPTION
Removed custom_taxonomies and replaced with site_taxonomies.
Removed the merging of categories and tags.
Put tags and categories (appropriately named from post_tag and category) into site_taxonomies.