### PR TITLE
CDP-1098: Delete options on uninstall

### DIFF
--- a/admin/partials/wp-es-feeder-admin-display.php
+++ b/admin/partials/wp-es-feeder-admin-display.php
@@ -22,12 +22,12 @@
     <?php
             $status_counts = $feeder->get_sync_status_counts();
 			// Import all the options from the databse
-			$options = get_option($this->plugin_name);
+			$options = get_option($this->plugin_name) ?: [];
 
 			$es_wpdomain = $options['es_wpdomain']?$options['es_wpdomain']:null;
 			$es_url = $options['es_url']?$options['es_url']:null;
             $es_token = $options['es_token']?$options['es_token']:null;
-			$es_post_types = $options['es_post_types']?$options['es_post_types']:null;
+			$es_post_types = $options['es_post_types']?$options['es_post_types']:[];
 			$es_api_data = array_key_exists('es_api_data', $options) && $options['es_api_data'] ? 1 : 0;
 			$es_post_language = array_key_exists('es_post_language', $options) && $options['es_post_language'] ? 1 : 0;
 

--- a/includes/class-wp-es-feeder.php
+++ b/includes/class-wp-es-feeder.php
@@ -235,7 +235,7 @@ if ( !class_exists( 'wp_es_feeder' ) ) {
     public function get_sync_status_counts() {
       global $wpdb;
       $opts = get_option( $this->plugin_name );
-      $post_types = $opts[ 'es_post_types' ];
+      $post_types = $opts[ 'es_post_types' ] ?: [];
       $formats = implode(',', array_fill(0, count($post_types), '%s'));
 
       $query = "SELECT IFNULL(ms.meta_value, 0) as status, COUNT(IFNULL(ms.meta_value, 0)) as total 
@@ -443,7 +443,7 @@ if ( !class_exists( 'wp_es_feeder' ) ) {
     public function get_resync_totals() {
       global $wpdb;
       $opts = get_option( $this->plugin_name );
-      $post_types = $opts[ 'es_post_types' ];
+      $post_types = $opts[ 'es_post_types' ] ?: [];
       $formats = implode(',', array_fill(0, count($post_types), '%s'));
       $query = "SELECT COUNT(*) as total, SUM(IF(ms.meta_value IS NOT NULL, 1, 0)) as complete FROM $wpdb->posts p 
                   LEFT JOIN (SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = '_cdp_sync_status') ms ON p.ID = ms.post_id

--- a/uninstall.php
+++ b/uninstall.php
@@ -30,6 +30,12 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
+$PLUGIN_NAME = 'wp-es-feeder';
+delete_option( $PLUGIN_NAME );
+delete_option( $PLUGIN_NAME . '_syncable_posts' );
+delete_option( 'cdp_languages' );
+delete_option( 'cdp_owners' );
+
 global $wpdb;
 $wpdb->delete($wpdb->postmeta, array('meta_key' => '_cdp_sync_status'));
 $wpdb->delete($wpdb->postmeta, array('meta_key' => '_cdp_sync_uid'));


### PR DESCRIPTION
Deleted all options created and used by the plugin  in the uninstall file.
Added some empty arrays to prevent warnings on first install before the settings page is saved.